### PR TITLE
M1チップ対応のためdocker-compose.ymlにplatformの記述を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - MYSQL_USER=laravel
       - MYSQL_PASSWORD=password
       - MYSQL_ROOT_PASSWORD=password
+    platform: linux/x86_64
   app:
     build:
       context: ./infra/docker/php


### PR DESCRIPTION
# やったこと
`platform: linux/x86_64`の記述を追加

# 証跡
<img width="292" alt="スクリーンショット 2022-06-09 3 46 55" src="https://user-images.githubusercontent.com/74942852/172693327-6e1bed52-2605-4b29-9ad1-07fcf56eb99b.png">
